### PR TITLE
Lock dependencies and import explicitly from ts-nats

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@provide/nats.ws": "1.0.5",
     "jsonwebtoken": "8.5.1",
     "node-nats-streaming": "0.2.6",
-    "ts-nats": "1.2.12",
+    "ts-nats": "1.2.14-2",
     "uuid": "3.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "@provide/nats.ws": "1.0.5",
     "jsonwebtoken": "8.5.1",
     "node-nats-streaming": "0.2.6",
-    "ts-nats": "1.2.4",
-    "uuid": "3.3.2"
+    "ts-nats": "1.2.12",
+    "uuid": "3.4.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.18",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   },
   "author": "Kyle Thomas <kyle@provide.services>",
   "dependencies": {
-    "@provide/nats.ws": "^1.0.5",
-    "jsonwebtoken": "^8.5.1",
-    "node-nats-streaming": "^0.2.6",
-    "ts-nats": "^1.2.4",
-    "uuid": "^3.3.2"
+    "@provide/nats.ws": "1.0.5",
+    "jsonwebtoken": "8.5.1",
+    "node-nats-streaming": "0.2.6",
+    "ts-nats": "1.2.4",
+    "uuid": "3.3.2"
   },
   "devDependencies": {
     "@types/jest": "^24.0.18",

--- a/src/nats.ts
+++ b/src/nats.ts
@@ -1,4 +1,4 @@
-import * as nats from 'ts-nats';
+import { connect, Payload, Client } from 'ts-nats';
 import { Config } from './env';
 import { INatsService, INatsSubscription, natsPayloadTypeBinary, natsPayloadTypeJson } from '.';
 
@@ -8,7 +8,7 @@ export class NatsService implements INatsService {
 
   private bearerToken: string | undefined;
   private config: Config;
-  private connection?: nats.Client | null;
+  private connection?: Client | null;
   private pubCount = 0;
   private servers: string[];
   private subscriptions: { [key: string]: INatsSubscription } = {};
@@ -34,9 +34,9 @@ export class NatsService implements INatsService {
 
     return new Promise((resolve, reject) => {
       const clientId = `${this.config.natsClientPrefix}-${uuidv4()}`;
-      nats.connect({
+      connect({
         encoding: this.config.natsEncoding,
-        payload: this.config.natsJson ? nats.Payload[natsPayloadTypeJson] : nats.Payload[natsPayloadTypeBinary],
+        payload: this.config.natsJson ? Payload[natsPayloadTypeJson] : Payload[natsPayloadTypeBinary],
         name: clientId,
         reconnect: true,
         maxPingOut: this.config.natsMaxPingOut,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5299,10 +5299,10 @@ ts-loader@^6.0.4:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
-ts-nats@1.2.12:
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/ts-nats/-/ts-nats-1.2.12.tgz#7de7a191177a0bf49939e3114d60fed4ad0cafa3"
-  integrity sha512-pYVUoXjQYtiYA3ShOFqt+9SEo2fpGNyX7TNMEDugU3E7H1HrGsgzc8J4I2fJDMkjPOMDd5K/OXdQg1Yefe1J4Q==
+ts-nats@1.2.14-2:
+  version "1.2.14-2"
+  resolved "https://registry.yarnpkg.com/ts-nats/-/ts-nats-1.2.14-2.tgz#4edfa5a99cb983b727b4e03d3280e9f851929b37"
+  integrity sha512-b0nPczfd8Z4+LQ5C7xWW391qiPsWNidhZRB9yrumQ0hfRHAos4NVwodPIZd78e/so3zBW5LRifejaAJE/UzNXA==
   dependencies:
     nuid "^1.1.2"
     ts-nkeys "^1.0.16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,7 +306,7 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@provide/nats.ws@^1.0.5":
+"@provide/nats.ws@1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@provide/nats.ws/-/nats.ws-1.0.5.tgz#599f2d760431bbedc8c1f43f55942f6fac8a3608"
   integrity sha512-h8oZFbZQSukSuf9EiQTWP7I6tpKbweshaaLm7NWJDFJevzhPCaEiSggAYzzFN4Jath36JH0+62ma+SRDjb4kYA==
@@ -3266,7 +3266,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-jsonwebtoken@^8.5.1:
+jsonwebtoken@8.5.1:
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
   integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
@@ -3819,7 +3819,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-nats-streaming@^0.2.6:
+node-nats-streaming@0.2.6:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/node-nats-streaming/-/node-nats-streaming-0.2.6.tgz#c5db3c58a034a5cb61a284691b1fe19b60bc4c4d"
   integrity sha512-UTS/tHextk+qdXl0fiSKFPU12eWsRkeRzbzo1zk6ZbXu/PnszKtnSwzxhVRYveU7VjDebYsAFpde1MjC5Y3Nvw==
@@ -5299,15 +5299,15 @@ ts-loader@^6.0.4:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
-ts-nats@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/ts-nats/-/ts-nats-1.2.4.tgz#be04c05bce305f586d6ac6a9b12b7d6cf6580502"
-  integrity sha512-bIC+PlwHplRqhooa9kE+QPcQ9RPGUXD2ruvdf6LoFpP6MjE6exVoRhYSydm0e5wk7VfuXpTbH1NoopTKHwlOKA==
+ts-nats@1.2.12:
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/ts-nats/-/ts-nats-1.2.12.tgz#7de7a191177a0bf49939e3114d60fed4ad0cafa3"
+  integrity sha512-pYVUoXjQYtiYA3ShOFqt+9SEo2fpGNyX7TNMEDugU3E7H1HrGsgzc8J4I2fJDMkjPOMDd5K/OXdQg1Yefe1J4Q==
   dependencies:
-    nuid "^1.1.0"
-    ts-nkeys "^1.0.12"
+    nuid "^1.1.2"
+    ts-nkeys "^1.0.16"
 
-ts-nkeys@^1.0.12, ts-nkeys@^1.0.16:
+ts-nkeys@^1.0.16:
   version "1.0.16"
   resolved "https://registry.yarnpkg.com/ts-nkeys/-/ts-nkeys-1.0.16.tgz#b0c6e7c4f16f976c7e7ddb6982fc789a2f971248"
   integrity sha512-1qrhAlavbm36wtW+7NtKOgxpzl+70NTF8xlz9mEhiA5zHMlMxjj3sEVKWm3pGZhHXE0Q3ykjrj+OSRVaYw+Dqg==
@@ -5552,7 +5552,7 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
-uuid@^3.3.2:
+uuid@3.4.0, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
If possible it would be great to lock dependencies to avoid externalities regarding unexpected version upgrades from the dependencies

The second issue is a more complicated on with is causing issues for both browser and react-native environments. From ts-nats there is an export for VERSION where it expects the pkgFile location to be different for tests and source. Hence its calling in global scope fs.existsSync which erroring for non-nodejs environments.

I've commented out in node_modules for testing but I would like to import explicitly from ts-nats to avoid getting the VERSION export, I'm unsure if this will fix it but it's worth the try. Im also going to look into merging a PR for ts-nats itself